### PR TITLE
Fix: correctly download remote ref.

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -22,6 +22,7 @@ export default async function run(command, config = {}, _try=0) {
     stdio: 'pipe',
     buffer: false,
     verbose: true,
+    raiseError: true,
     retries: 0
   }, config);
 
@@ -76,9 +77,11 @@ export default async function run(command, config = {}, _try=0) {
       return await run(command, retryOpts, _try + 1);
     }
 
-    let err = Error(`Error running command: ${command}`);
-    err.retired = _try;
-    throw err;
+    if (opts.raiseError) {
+      let err = Error(`Error running command: ${command}`);
+      err.retired = _try;
+      throw err;
+    }
   }
 
   return [stdout, stderr];

--- a/src/vcs/git.js
+++ b/src/vcs/git.js
@@ -1,5 +1,7 @@
 import run from '../run';
 
+let REMOTE = 'tc-vcs-remote';
+
 export async function clone(config, source, dest) {
   return await run(`${config.git} clone ${source} ${dest}`, {
     retries: 20
@@ -19,7 +21,11 @@ export async function revision(config, cwd) {
 }
 
 export async function checkoutRevision(config, cwd, repository, ref, rev) {
-  await run(`${config.git} fetch ${repository} ${ref}`, { 
+  await run(`${config.git} remote add ${REMOTE} ${repository}`, {
+    cwd,
+    raiseError: false
+  });
+  await run(`${config.git} fetch ${repository} ${ref}:refs/remotes/${REMOTE}/${ref}`, {
     cwd,
     retries: 20
   });

--- a/test/integration/checkout_test.js
+++ b/test/integration/checkout_test.js
@@ -106,6 +106,22 @@ suite('checkout', function() {
       '3b241b02a9860354d416504a476d597783101ac5'
     );
   });
+
+  test('checkout remote branch', async function () {
+    let url = 'https://github.com/lightsofapollo/build-mozharness';
+    let dest = `${this.home}/clones/mozharness`;
+    await run([
+      'checkout',
+      dest,
+      url,
+      url,
+      'emulator-perf-new'
+    ]);
+    assert.equal(
+      (await run(['revision', dest]))[0],
+      '35d7cc561a62eaec54ca53a3d43d1443754f9c98'
+    );
+  });
 });
 
 


### PR DESCRIPTION
If you do "git fetch <remote> <ref>" and ref doesn't exist locally, git
will fetch the remote but will not download it. We need to specify the
local ref: "git fetch <remote> <ref>:refs/remotes/origin/<ref>".