### PR TITLE
Fix: branch names are allowed to contain slashes (/).

### DIFF
--- a/src/vcs/git.js
+++ b/src/vcs/git.js
@@ -1,5 +1,4 @@
 import run from '../run';
-var path = require('path');
 
 let REMOTE = 'tc-vcs-remote';
 
@@ -21,7 +20,7 @@ async function getRefRemote(config, cwd, ref) {
     let branch = branches[i].trim();
     // If our ref is there and it is not the <remote>/HEAD -> <ref> line
     if (branch.indexOf(ref) != -1 && branch.indexOf('HEAD') == -1) {
-      let remote = path.basename(path.dirname(branch));
+      let remote = branch.split('/')[0];
       return remote;
     }
   }

--- a/test/integration/checkout_test.js
+++ b/test/integration/checkout_test.js
@@ -154,6 +154,22 @@ suite('checkout', function() {
       'd60ffcf4b975f6f7b42215c7aed53274ceb6eb88'
     );
   });
+
+  test('checkout slash', async function () {
+    let url = 'https://github.com/walac/tc-vcs-slash-test-case';
+    let dest = `${this.home}/clones/mozharness`;
+    await run([
+      'checkout',
+      dest,
+      url,
+      url,
+      'bugz/9999'
+    ]);
+    assert.equal(
+      (await run(['revision', dest]))[0],
+      'eafd3e166af5a77d4138790ae43a4d4f1a043d2a'
+    );
+  });
 });
 
 


### PR DESCRIPTION
If a branch name contains a slash, like "bugz/9999", tc-vcs will
interpret the "9999" as the branch name and the "bugz" string as the
remote name.

We change this behavior by observing that the first part of the remote
branch is the remote.