### PR TITLE
Fix: force git fetching of non fast forward branches.

### DIFF
--- a/src/vcs/git.js
+++ b/src/vcs/git.js
@@ -54,7 +54,7 @@ export async function checkoutRevision(config, cwd, repository, ref, rev) {
     raiseError: false
   });
   try {
-    await run(`${config.git} fetch ${repository} ${ref}:refs/remotes/${remote}/${ref}`, {
+    await run(`${config.git} fetch -f ${repository} ${ref}:refs/remotes/${remote}/${ref}`, {
       cwd,
       retries: 1
     });


### PR DESCRIPTION
If a branch is cached and its history is changed in the remote, git
fetch will fail because it will not be a fast forward update.

We use the -f option to always update the cached branch.