### PR TITLE
Use exponential back-off (not tested)

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -4,7 +4,7 @@ import eventToPromise from 'event-to-promise';
 import fs from 'fs';
 
 const DEFAULT_RETRIES = 10;
-const RETRY_SLEEP = 1000;
+const RETRY_SLEEP = 10000;
 
 /**
 Wrapper around process spawning with extra logging.
@@ -70,7 +70,7 @@ export default async function run(command, config = {}, _try=0) {
       );
 
       // Sleep for a bit..
-      await new Promise(accept => setTimeout(accept, _try * RETRY_SLEEP));
+      await new Promise(accept => setTimeout(accept, Math.pow(2, _try) * RETRY_SLEEP));
       let retryOpts = Object.assign({}, opts);
 
       // Issue the retry...

--- a/src/run.js
+++ b/src/run.js
@@ -5,6 +5,7 @@ import fs from 'fs';
 
 const DEFAULT_RETRIES = 10;
 const RETRY_SLEEP = 10000;
+const RANDOMIZATION_FACTOR = 0.25;
 
 /**
 Wrapper around process spawning with extra logging.
@@ -70,7 +71,10 @@ export default async function run(command, config = {}, _try=0) {
       );
 
       // Sleep for a bit..
-      await new Promise(accept => setTimeout(accept, Math.pow(2, _try) * RETRY_SLEEP));
+      let delay = Math.pow(2, _try) * RETRY_SLEEP;
+      let rf = RANDOMIZATION_FACTOR; // Apply randomization factor
+      delay = delay * (Math.random() * 2 * rf + 1 - rf);
+      await new Promise(accept => setTimeout(accept, delay));
       let retryOpts = Object.assign({}, opts);
 
       // Issue the retry...


### PR DESCRIPTION
Back-offs should be:
 - 10s
 - 20s
 - 40s
 - 80s
....

Maybe `RETRY_SLEEP` should be `20s` instead of just `10s` as I suggest we increase to here.

------
This is just not tested, just a quick hack to show that maybe we should consider something like this.