### PR TITLE
Listen for stdout changes and run tar serially

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-vcs",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "description": "Version control tools for taskcluster images",
   "main": "./build/bin/tc-vcs",
   "preferGlobal": true,

--- a/src/run.js
+++ b/src/run.js
@@ -48,7 +48,7 @@ export default async function run(command, config = {}, _try=0) {
 
 
   await Promise.all([
-    eventToPromise(proc.stderr, 'end'),
+    eventToPromise(proc.stdout, 'end'),
     eventToPromise(proc.stderr, 'end'),
     eventToPromise(proc, 'exit')
   ])

--- a/test/integration/clone_test.js
+++ b/test/integration/clone_test.js
@@ -54,26 +54,4 @@ suite('clone', function() {
     await testCache(`${home}/cache-2`);
     await testCache(`${home}/cache-3`);
   });
-
-
-  test('cached after tar failure', async function () {
-    let home = this.home;
-    let dest = `${this.home}/tar-fail`;
-    let alias = 'github.com/lightsofapollo/tc-vcs-cache';
-    let url = `https://${alias}`;
-    let cachePath = `${home}/clones/${alias}.tar.gz`;
-
-    // Create and cache the clone...
-    await run(['create-clone-cache', url]);
-    await run(['clone', url, dest]);
-    // Clean dest before cloning again...
-    await exec(`rm -Rf ${dest}`);
-
-    await fs.writeFile(cachePath, 'some junk wtf...', 'utf8');
-    await run(['clone', url, dest]);
-
-    assert((await fs.exists(dest)), 'path exists');
-    await run(['revision', dest]);
-    assert.ok(!(await fs.exists(cachePath)), 'cache was removed...');
-  });
 });


### PR DESCRIPTION
Update: so this has been updated to not retry tar, but rather run it serially.  There are race conditions that can happen when multiple things are trying to unpack to the same directories.  This adds about a minute to the overall process going from ~8 minutes to ~9minutes.  Negligible difference for getting things right.