### PR TITLE
[bug 1206395] Verify artifact exists before downloading

### DIFF
--- a/src/cli/clone.js
+++ b/src/cli/clone.js
@@ -54,6 +54,15 @@ export default async function main(config, argv) {
     args.dest
   );
 
+
+  if (!archivePath && !args.force_clone) {
+    console.error(
+      '[taskcluster-vcs:error] Could not clone repository using cached copy. ' +
+      'Use \'--force-clone\' to perform a full clone.'
+    );
+    process.exit(1);
+  }
+
   let vcsConfig = await detect(args.url);
   let vcs = require('../vcs/' + vcsConfig.type);
 
@@ -64,14 +73,6 @@ export default async function main(config, argv) {
     await artifacts.extract(archivePath, args.dest);
     await vcs.pull(config, args.dest, args.url);
   } else {
-    if (!args.force_clone) {
-      console.error(
-        '[taskcluster-vcs:error] Could not clone repository using cached copy. ' +
-        'Use \'--force-clone\' to perform a full clone.'
-      );
-      process.exit(1);
-    }
-
     await vcs.clone(config, args.url, args.dest);
   }
 }

--- a/src/cli/create-clone-cache.js
+++ b/src/cli/create-clone-cache.js
@@ -33,6 +33,12 @@ export default async function main(config, argv) {
     help: 'Taskcluster Index namespace'
   });
 
+  parser.addArgument(['--force-clone'], {
+    action: 'storeTrue',
+    defaultValue: false,
+    help: 'Clone from remote repository when cached copy is not available'.trim()
+  });
+
   parser.addArgument(['url'], {
     help: 'url which to clone from'
   });
@@ -40,9 +46,14 @@ export default async function main(config, argv) {
   // configuration for clone/update....
   let args = parser.parseArgs(argv);
   let dir = temp.path('tc-vcs-create-clone-cache');
+  let checkoutArgs = [dir, args.url, '--namespace', args.namespace]
+
+  if (args.force_clone) {
+    checkoutArgs.unshift('--force-clone');
+  }
 
   // Clone and update cache...
-  await checkout(config, [dir, args.url, '--namespace', args.namespace]);
+  await checkout(config, checkoutArgs);
 
   let queue = clitools.getTcQueue(args.proxy);
   let index = clitools.getTcIndex(args.proxy);

--- a/src/cli/create-repo-cache.js
+++ b/src/cli/create-repo-cache.js
@@ -51,19 +51,29 @@ export default async function main(config, argv) {
     `
   });
 
+  parser.addArgument(['--force-clone'], {
+    action: 'storeTrue',
+    help: 'Clone from remote repository when cached copy is not available'.trim()
+  });
+
   // configuration for clone/update....
   let args = parser.parseArgs(argv);
   let queue = clitools.getTcQueue(args.proxy);
   let index = clitools.getTcIndex(args.proxy);
   let workspace = temp.path('tc-vcs-create-repo-cache');
   let artifacts = new Artifacts(config.repoCache, queue, index);
-
-  // Clone and update cache...
-  await repoCheckout(config, [
+  let repoCheckoutArgs = [
     workspace, args.url, args.manifest,
     '--namespace', args.namespace,
-    '--branch', args.branch
-  ]);
+    '--branch', args.branch,
+  ];
+
+  if (args.force_clone) {
+    repoCheckoutArgs.unshift('--force-clone');
+  }
+
+  // Clone and update cache...
+  await repoCheckout(config, repoCheckoutArgs);
 
   // Get a list of the projects so we can build the tars...
   let projects = await vcsRepo.list(workspace);

--- a/src/cli/repo-checkout.js
+++ b/src/cli/repo-checkout.js
@@ -36,6 +36,12 @@ export default async function main(config, argv) {
     `.trim()
   });
 
+  parser.addArgument(['--force-clone'], {
+    action: 'storeTrue',
+    defaultValue: false,
+    help: 'Clone from remote repository when cached copy is not available'.trim()
+  });
+
   parser.addArgument(['-b', '--branch'], {
     dest: 'branch',
     defaultValue: 'master',
@@ -104,6 +110,10 @@ export default async function main(config, argv) {
     // don't include values that are null, etc...
     return !!v;
   });
+
+  if (args.force_clone) {
+    checkoutArgs.unshift('--force-clone');
+  }
 
   // Checkout the underlying repository before running repo...
   await checkout(config, checkoutArgs);

--- a/src/cli/repo-checkout.js
+++ b/src/cli/repo-checkout.js
@@ -165,7 +165,12 @@ export default async function main(config, argv) {
   // Extraction of archives should *not* be done in parallel because of race
   // conditions with writing to the same directories.
   for (let archive of archivesToExtract) {
+    // Skip if archive does not exist.  This happens when extracted archive already
+    // exists.
     if (!archive) continue;
+    // If no archive was downloaded, processing should only continue if force-clone
+    // option was specified. This is to prevent accidentally doing full clones of repositories
+    // unless explicitly forced.
     if (!archive.archivePath) {
       if (!args.force_clone) {
         console.error(

--- a/test/integration/checkout_revision_test.js
+++ b/test/integration/checkout_revision_test.js
@@ -8,7 +8,7 @@ suite('checkout-revision', function() {
   test('(git) cached -> then update', async function () {
     let alias = 'github.com/lightsofapollo/tc-vcs-cache';
     let url = `https://${alias}`;
-    await run(['create-clone-cache', url]);
+    await run(['create-clone-cache', '--force-clone', url]);
 
     let dest =  `${this.home}/clones/git-checkout-revision/`;
     await run([
@@ -39,7 +39,7 @@ suite('checkout-revision', function() {
   test('(hg) cached -> then update', async function () {
     let alias = 'bitbucket.org/lightsofapollo/hgcache';
     let url = `https://${alias}`;
-    await run(['create-clone-cache', url]);
+    await run(['create-clone-cache', '--force-clone', url]);
 
     let dest = `${this.home}/clones/hg-checkout-revision`;
     await run([

--- a/test/integration/checkout_test.js
+++ b/test/integration/checkout_test.js
@@ -30,11 +30,13 @@ suite('checkout', function() {
     let dest = `${this.home}/clones/tc-vcs-cache`;
     await run([
       'checkout',
+      '--force-clone',
       dest,
       'https://github.com/lightsofapollo/tc-vcs-cache'
     ]);
     await run([
       'checkout',
+      '--force-clone',
       dest,
       'https://bitbucket.org/lightsofapollo/hgtesting',
     ]);
@@ -49,6 +51,7 @@ suite('checkout', function() {
     async function checkout() {
       await run([
         'checkout',
+        '--force-clone',
         dest,
         url,
         url,
@@ -69,11 +72,12 @@ suite('checkout', function() {
   test('(with cache) checkout fresh then checkout again', async function () {
     let url = 'https://github.com/lightsofapollo/tc-vcs-cache'
     let dest = `${this.home}/clones/tc-vcs-cache`;
-    await run(['create-clone-cache', url]);
+    await run(['create-clone-cache', '--force-clone', url]);
 
     async function checkout() {
       await run([
         'checkout',
+        '--force-clone',
         dest,
         url,
         url,
@@ -97,6 +101,7 @@ suite('checkout', function() {
     let dest = `${this.home}/clones/tc-vcs-cache`;
     await run([
       'checkout',
+      '--force-clone',
       dest,
       url
     ]);
@@ -112,6 +117,7 @@ suite('checkout', function() {
     let dest = `${this.home}/clones/mozharness`;
     await run([
       'checkout',
+      '--force-clone',
       dest,
       url,
       url,
@@ -128,6 +134,7 @@ suite('checkout', function() {
     let dest = `${this.home}/clones/mozharness`;
     await run([
       'checkout',
+      '--force-clone',
       dest,
       url,
       url,
@@ -144,6 +151,7 @@ suite('checkout', function() {
     let dest = `${this.home}/clones/mozharness`;
     await run([
       'checkout',
+      '--force-clone',
       dest,
       url,
       url,
@@ -160,6 +168,7 @@ suite('checkout', function() {
     let dest = `${this.home}/clones/mozharness`;
     await run([
       'checkout',
+      '--force-clone',
       dest,
       url,
       url,

--- a/test/integration/clone_test.js
+++ b/test/integration/clone_test.js
@@ -1,15 +1,25 @@
-import { exec } from 'mz/child_process';
-import run from './run';
-import fs from 'mz/fs';
 import assert from 'assert';
+import { exec } from 'mz/child_process';
+import fs from 'mz/fs';
 import mkdirp from 'mkdirp';
+import path from 'path';
+import slugid from 'slugid';
+
+import createTask from './taskcluster';
+import hash from '../../src/hash';
+import detectLocal from '../../src/vcs/detect_local';
+import { Index } from 'taskcluster-client';
+import run from './run';
+
+let index = new Index();
 
 suite('clone', function() {
   test('hg', async function() {
     let dest = `${this.home}/hg`;
     let out = await run([
       'clone',
-      '--namespace=not-vcs-test',
+      '--namespace=public.test.taskcluster-vcs-garbage',
+      '--force-clone',
       'https://bitbucket.org/lightsofapollo/hgtesting',
       dest
     ]);
@@ -22,6 +32,7 @@ suite('clone', function() {
     let dest = `${this.home}/git`;
     await run([
       'clone',
+      '--force-clone',
       '--namespace=not-vcs-test',
       'https://bitbucket.org/lightsofapollo/gittesting',
       dest
@@ -35,7 +46,7 @@ suite('clone', function() {
     let home = this.home;
     let alias = 'github.com/lightsofapollo/tc-vcs-cache';
     let url = `https://${alias}`;
-    await run(['create-clone-cache', url]);
+    await run(['create-clone-cache', '--force-clone', url]);
     async function testCache (dest) {
       await run([
         'clone',
@@ -53,5 +64,71 @@ suite('clone', function() {
     await testCache(`${home}/cache-1`);
     await testCache(`${home}/cache-2`);
     await testCache(`${home}/cache-3`);
+  });
+
+  test('force-clone disabled (by default) - fails to clone', async function(done) {
+    let alias = 'bitbucket.org/lightsofapollo/hgtesting'
+    let dest = `${this.home}/hg`;
+    let namespace = `public.test.taskcluster-vcs-garbage.${slugid.v4()}`;
+    let taskId = await createTask();
+
+    let indexOptions = {
+      taskId: taskId,
+      rank: 1,
+      data: {},
+      expires: new Date(Date.now() + 60 * 1000)
+    };
+
+    await index.insertTask(`${namespace}.${hash(alias)}`, indexOptions);
+
+    let out = await run([
+      'clone',
+      `--namespace=${namespace}`,
+      // XXX: Change all references to these repos in the tests
+      'https://bitbucket.org/lightsofapollo/hgtesting',
+      dest
+    ]).catch(async (err) => {;
+      let exists = await fs.exists(dest);
+      assert.ok(!exists, 'Cloned path should not exist.');
+      assert.ok(
+        err.message.includes('Could not clone repository using cached copy') &&
+        err.message.includes('force-clone'),
+        'Error message does not indicate that force-clone should be used'
+      );
+      done();
+    });
+
+    assert(false, 'Command completed successfully when it should not have');
+  });
+
+  test('force-clone enabled - clone from repository when no artifact present', async function() {
+    let alias = 'bitbucket.org/lightsofapollo/hgtesting'
+    let dest = `${this.home}/hg`;
+    let namespace = `public.test.taskcluster-vcs-garbage.${slugid.v4()}`;
+    let taskId = await createTask();
+
+    let indexOptions = {
+      taskId: taskId,
+      rank: 1,
+      data: {},
+      expires: new Date(Date.now() + 60 * 1000)
+    };
+
+    await index.insertTask(`${namespace}.${hash(alias)}`, indexOptions);
+
+    let out = await run([
+      'clone',
+      '--force-clone',
+      `--namespace=${namespace}`,
+      // XXX: Change all references to these repos in the tests
+      'https://bitbucket.org/lightsofapollo/hgtesting',
+      dest
+    ]);
+
+    let exists = await fs.exists(dest);
+    assert.ok(exists, 'Cloned path does not exist.');
+
+    let localType = await detectLocal(dest);
+    assert.equal(localType.type, 'hg', 'Cloned repository is not the correct vcs type');
   });
 });

--- a/test/integration/clone_test.js
+++ b/test/integration/clone_test.js
@@ -66,7 +66,7 @@ suite('clone', function() {
     await testCache(`${home}/cache-3`);
   });
 
-  test('force-clone disabled (by default) - fails to clone', async function(done) {
+  test('@taskcluster force-clone disabled (by default) - fails to clone', async function(done) {
     let alias = 'bitbucket.org/lightsofapollo/hgtesting'
     let dest = `${this.home}/hg`;
     let namespace = `public.test.taskcluster-vcs-garbage.${slugid.v4()}`;
@@ -101,7 +101,7 @@ suite('clone', function() {
     assert(false, 'Command completed successfully when it should not have');
   });
 
-  test('force-clone enabled - clone from repository when no artifact present', async function() {
+  test('@taskcluster force-clone enabled - clone from repository when no artifact present', async function() {
     let alias = 'bitbucket.org/lightsofapollo/hgtesting'
     let dest = `${this.home}/hg`;
     let namespace = `public.test.taskcluster-vcs-garbage.${slugid.v4()}`;

--- a/test/integration/create_clone_cache_test.js
+++ b/test/integration/create_clone_cache_test.js
@@ -16,14 +16,14 @@ suite('create clone cache', function() {
   test('create cache (git)', async function() {
     let alias = 'bitbucket.org/lightsofapollo/gittesting'
     let url = `https://${alias}`;
-    await run(['create-clone-cache', url])
+    await run(['create-clone-cache', '--force-clone', url])
     assert(fs.exists(`${this.home}/clones/${alias}.tar.gz`));
   });
 
   test('create cache (hg)', async function() {
     let alias = 'bitbucket.org/lightsofapollo/hgtesting'
     let url = `https://${alias}`;
-    await run(['create-clone-cache', url])
+    await run(['create-clone-cache', '--force-clone', url])
     assert(fs.exists(`${this.home}/clones/${alias}.tar.gz`));
   });
 
@@ -38,6 +38,7 @@ suite('create clone cache', function() {
     await run([
       'create-clone-cache',
       url,
+      '--force-clone',
       '--namespace', namespace,
       '--task-id', taskId,
       '--run-id=0',

--- a/test/integration/create_clone_cache_test.js
+++ b/test/integration/create_clone_cache_test.js
@@ -28,7 +28,7 @@ suite('create clone cache', function() {
   });
 
   test('@taskcluster upload cache', async function() {
-    let namespace = 'public.test.jlal.' + slugid.v4();
+    let namespace = 'public.test.taskcluster-vcs-garbage.' + slugid.v4();
     let taskId = await createTask();
 
     let alias = 'bitbucket.org/lightsofapollo/hgtesting'

--- a/test/integration/create_repo_cache_test.js
+++ b/test/integration/create_repo_cache_test.js
@@ -18,7 +18,7 @@ suite('create repo cache', function() {
 
   test('create cache', async function() {
     let source = 'bitbucket.org/lightsofapollo/gittesting/master';
-    await run(['create-repo-cache', url, 'sources.xml']);
+    await run(['create-repo-cache', '--force-clone', url, 'sources.xml']);
     assert(fs.exists(`${this.home}/repo/sources/${source}.tar.gz`));
   });
 
@@ -32,6 +32,7 @@ suite('create repo cache', function() {
     let taskId = await createTask();
     await run([
       'create-repo-cache',
+      '--force-clone',
       '--upload',
       '--namespace', namespace,
       '--task-id', taskId,

--- a/test/integration/repo_checkout_test.js
+++ b/test/integration/repo_checkout_test.js
@@ -18,7 +18,7 @@ suite('repo-checkout', function() {
   test('successful repo sync', async function () {
     let manifest = 'sources.xml';
     await run([
-      'repo-checkout', dest, url, manifest
+      'repo-checkout', '--force-clone', dest, url, manifest
     ]);
 
     let [rev] = await run(['revision', `${dest}/gittesting`]);
@@ -28,8 +28,14 @@ suite('repo-checkout', function() {
   test('(cached) repo sync and resync', async function() {
     let manifest = 'sources.xml';
     let home = this.home;
-    await run(['create-repo-cache', url, manifest]);
+    // create-repo-cache does not create a cache of the original repo that contains
+    // the source manifest so later calling repo-checkout without force-clone causes
+    // all sorts of issues
+    await run(['create-clone-cache', '--force-clone', url]);
+    await run(['create-repo-cache', '--force-clone', url, manifest]);
 
+
+    let force = false
     async function checkout() {
       await run(['repo-checkout', dest, url, manifest]);
       let statsUrl = fsPath.join(dest, '.repo', '.tc-vcs-cache-stats.json');

--- a/test/vcs/repo_test.js
+++ b/test/vcs/repo_test.js
@@ -19,7 +19,7 @@ suite('vcs/repo', function() {
       let dir = `${this.home}/test`;
 
       // cheat by checking out the repository
-      await run(['checkout', dir, url]);
+      await run(['checkout', '--force-clone', dir, url]);
       await vcsRepo.init(dir, manifest);
       await vcsRepo.sync(dir);
     });
@@ -29,7 +29,7 @@ suite('vcs/repo', function() {
       let dir = `${this.home}/test`;
 
       // cheat by checking out the repository
-      await run(['checkout', dir, url]);
+      await run(['checkout', '--force-clone', dir, url]);
       await vcsRepo.init(dir, `${dir}/includes.xml`);
       await vcsRepo.sync(dir);
     });


### PR DESCRIPTION
When the artifact does not exist for a repository, instead of downloading a 404 json blob and trying to extract it, it will either:
A) perform a full clone from the remote repo if --force-clone is enabled
B) fail (default behavior)

Here is a failure:
https://tools.taskcluster.net/task-inspector/#3dinbZ3pT1mLoalr-G_EVA/0

Success:
https://tools.taskcluster.net/task-inspector/#RSNMG7_rQsmVweAmu_I5cQ/0