### PR TITLE
Reduce the amount of parallelism when calling repo sync

### DIFF
--- a/src/vcs/repo.js
+++ b/src/vcs/repo.js
@@ -149,7 +149,7 @@ export async function init(cwd, manifest, opts={}) {
 
 export async function sync(cwd, opts={}) {
   opts = Object.assign({
-    concurrency: 100,
+    concurrency: 1,
     project: null
   }, opts);
 


### PR DESCRIPTION
When calling repo sync taskcluster-vcs will try to do things in the
most expedient ways, which includes running it with -j100 by default
and also calling repo sync for each of the projects in parallel.

This is believed to cause numerous connections to the git servers.  When
caches are used, and only changes need to be synced, calling `repo sync
-j1` on the parent project as a whole does not seem to be slower, and in
many trials faster.

For those that would still like to speed up their syncs, an option can
now be passed in to override the default value of 1.