### PR TITLE
Print version information to standard error so we can diagnose issues easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /build
 /test/integration/clones/
+.gitinfo

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "tc-vcs": "./build/bin/tc-vcs.js"
   },
   "scripts": {
-    "prepublish": "6to5 -s -e src --out-dir build",
+    "id": "(git rev-parse HEAD || hg id || echo '---') > .gitinfo",
+    "compile": "npm run id && 6to5 -s -e src --out-dir build",
+    "prepublish": "npm run compile",
+    "pretest": "npm run compile",
     "test": "mocha $(find test -name '*_test.js')",
     "test-no-upload": "mocha $(find test -name '*_test.js') --grep '@taskcluster' --invert"
   },

--- a/src/bin/tc-vcs.js
+++ b/src/bin/tc-vcs.js
@@ -49,6 +49,17 @@ function help() {
 }
 
 function cli(name, config, argv) {
+  let version = require('../../package.json').version;
+  let commit = '---';
+  let commitFile = fsPath.join(__dirname, '../../.gitinfo');
+  if (fs.existsSync(commitFile)) {
+    try {
+      commit = fs.readFileSync(commitFile).toString().trim().slice(0,7);
+    } catch (err) { }
+  }
+  // Write to standard error so that the unit tests can pass.  They default to
+  // reading the stdandard output of this program.
+  process.stderr.write('taskcluster-vcs ' + version + ' (' + commit + ')\n');
   require(name)(config, argv).catch((err) => {
     console.log(err.stack || err);
     if (err) {


### PR DESCRIPTION
I have no clue if this is really the right thing to do.  Please feel free to
ignore this commit.  The reason that I print to standard error instead of using
e.g. console.log and standard output is that I don't want to dirty up the output
that the unit tests expect.  This information is really helpful when diagnosing
random tc-vcs stacks.
