### PR TITLE
Schedule cache jobs within the same graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "superagent-promise": "^0.2.0",
     "tar-fs": "^1.3.0",
     "tar-stream": "^1.1.1",
-    "taskcluster-client": "^0.19.4",
+    "taskcluster-client": "0.21.3",
     "url-join": "0.0.1",
     "xml2js": "^0.4.4"
   },


### PR DESCRIPTION
@selenamarie  I'm not sure if this helps out when running the cache jobs, but this would not require taskcluster-cli anymore and use our node taskcluster-client libraries for submitting things.  Also, it makes uses of slugid.nice() so we don't have task IDs starting with a hyphen.  Feel free to drop this PR if it doesn't seem helpful.