### PR TITLE
Add support for bitbucket repos again and fix checkout tests

### DIFF
--- a/src/cli/checkout.js
+++ b/src/cli/checkout.js
@@ -97,6 +97,8 @@ export default async function main(config, argv) {
     cloneArgs.unshift('--force-clone');
   }
 
+  cloneArgs.unshift(`--namespace=${args.namespace}`);
+
   let remoteVcsConfig = await detect(args.baseUrl);
 
   // First check if the directory exists if it does it must be a detectable vcs

--- a/src/cli/repo-checkout.js
+++ b/src/cli/repo-checkout.js
@@ -174,7 +174,7 @@ export default async function main(config, argv) {
     if (!archive.archivePath) {
       if (!args.force_clone) {
         console.error(
-          `[taskcluster:error] Cached copy of '${archive.projectName}' could not be found. ` +
+          `[taskcluster-vcs:error] Cached copy of '${archive.projectName}' could not be found. ` +
           `Use '--force-clone' to perform a full clone`
         );
         process.exit(1);


### PR DESCRIPTION
I'm not sure when things changed, but tests were failing because for bitbucket repos, the detectHg method was failing.  Previously this must have been returning correctly, but now it looks like we cannot rely on content-type any longer.  Looked around the bitbucket api and it looks like we can count on this json blob being returned with the scm type.

Also added a couple of new tests for missing artifacts and unindexed repos.

While testing discovered that we are not passing in the namespace given to `tc-vcs checkout` to the clone that's performed.