### PR TITLE
Update npm shrinkwrap - slugid dependency change

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-vcs",
-  "version": "2.3.17",
+  "version": "2.3.22",
   "dependencies": {
     "6to5": {
       "version": "3.6.5",
@@ -28,9 +28,9 @@
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
             },
             "escape-string-regexp": {
-              "version": "1.0.3",
+              "version": "1.0.4",
               "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "has-ansi": {
               "version": "0.1.0",
@@ -39,7 +39,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -51,7 +51,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -75,11 +75,13 @@
               "dependencies": {
                 "graceful-fs": {
                   "version": "2.0.3",
-                  "from": "graceful-fs@>=2.0.0 <2.1.0"
+                  "from": "graceful-fs@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
                 },
                 "minimatch": {
                   "version": "0.2.14",
                   "from": "minimatch@>=0.2.12 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.7.3",
@@ -115,7 +117,8 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0"
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -125,6 +128,18 @@
               "version": "0.1.6",
               "from": "async-each@>=0.1.5 <0.2.0",
               "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "fsevents": {
+              "version": "0.3.8",
+              "from": "fsevents@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "2.2.0",
+                  "from": "nan@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.2.0.tgz"
+                }
+              }
             }
           }
         },
@@ -272,7 +287,8 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0"
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
                       "version": "3.0.0",
@@ -333,9 +349,9 @@
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 },
                 "recast": {
-                  "version": "0.10.39",
+                  "version": "0.10.42",
                   "from": "recast@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.42.tgz",
                   "dependencies": {
                     "esprima-fb": {
                       "version": "15001.1001.0-dev-harmony-fb",
@@ -348,9 +364,9 @@
                       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                     },
                     "ast-types": {
-                      "version": "0.8.12",
-                      "from": "ast-types@0.8.12",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                      "version": "0.8.15",
+                      "from": "ast-types@0.8.15",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz"
                     }
                   }
                 }
@@ -452,7 +468,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "2.2.4",
-              "from": "lru-cache@>=2.2.0 <2.3.0"
+              "from": "lru-cache@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
             }
           }
         }
@@ -508,9 +525,9 @@
       }
     },
     "js-yaml": {
-      "version": "3.4.6",
+      "version": "3.5.2",
       "from": "js-yaml@>=3.2.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.2.tgz",
       "dependencies": {
         "argparse": {
           "version": "1.0.3",
@@ -530,14 +547,9 @@
           }
         },
         "esprima": {
-          "version": "2.7.0",
+          "version": "2.7.1",
           "from": "esprima@>=2.6.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
-        },
-        "inherit": {
-          "version": "2.2.2",
-          "from": "inherit@>=2.2.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
         }
       }
     },
@@ -591,9 +603,9 @@
       }
     },
     "promise": {
-      "version": "7.0.4",
+      "version": "7.1.1",
       "from": "promise@>=3.2.0",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
       "dependencies": {
         "asap": {
           "version": "2.0.3",
@@ -619,7 +631,8 @@
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@>=2.2.6 <2.3.0"
+              "from": "rimraf@>=2.2.6 <2.3.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             }
           }
         },
@@ -632,6 +645,18 @@
           "version": "2.2.0",
           "from": "debug@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        }
+      }
+    },
+    "slugid": {
+      "version": "1.1.0",
+      "from": "slugid@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slugid/-/slugid-1.1.0.tgz",
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.1",
+          "from": "uuid@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
         }
       }
     },
@@ -672,7 +697,7 @@
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.0.0 <3.0.0",
+          "from": "debug@>=2.1.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "reduce-component": {
@@ -731,7 +756,8 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0"
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         }
@@ -743,9 +769,9 @@
       "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-0.2.0.tgz"
     },
     "tar-fs": {
-      "version": "1.8.1",
+      "version": "1.9.0",
       "from": "tar-fs@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.9.0.tgz",
       "dependencies": {
         "pump": {
           "version": "1.0.1",
@@ -803,9 +829,9 @@
           }
         },
         "readable-stream": {
-          "version": "2.0.4",
+          "version": "2.0.5",
           "from": "readable-stream@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
@@ -814,7 +840,8 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0"
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "isarray": {
               "version": "0.0.1",
@@ -823,7 +850,7 @@
             },
             "process-nextick-args": {
               "version": "1.0.6",
-              "from": "process-nextick-args@>=1.0.0 <1.1.0",
+              "from": "process-nextick-args@>=1.0.6 <1.1.0",
               "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
             },
             "string_decoder": {
@@ -846,13 +873,13 @@
       }
     },
     "taskcluster-client": {
-      "version": "0.21.3",
-      "from": "taskcluster-client@0.21.3",
-      "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-0.21.3.tgz",
+      "version": "0.23.5",
+      "from": "taskcluster-client@>=0.23.4 <0.24.0",
+      "resolved": "https://registry.npmjs.org/taskcluster-client/-/taskcluster-client-0.23.5.tgz",
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.5.0 <4.0.0",
+          "from": "lodash@>=3.6.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
         "debug": {
@@ -861,9 +888,9 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "superagent": {
-          "version": "1.5.0",
+          "version": "1.6.1",
           "from": "superagent@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.6.1.tgz",
           "dependencies": {
             "qs": {
               "version": "2.3.3",
@@ -891,9 +918,9 @@
               "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz"
             },
             "cookiejar": {
-              "version": "2.0.1",
-              "from": "cookiejar@2.0.1",
-              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz"
+              "version": "2.0.6",
+              "from": "cookiejar@2.0.6",
+              "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz"
             },
             "reduce-component": {
               "version": "1.0.1",
@@ -963,7 +990,8 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -977,22 +1005,27 @@
             "hawk": {
               "version": "1.0.0",
               "from": "hawk@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
-                  "from": "hoek@>=0.9.0 <0.10.0"
+                  "from": "hoek@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
                 },
                 "boom": {
                   "version": "0.4.2",
-                  "from": "boom@>=0.4.0 <0.5.0"
+                  "from": "boom@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
                 },
                 "cryptiles": {
                   "version": "0.2.2",
-                  "from": "cryptiles@>=0.2.0 <0.3.0"
+                  "from": "cryptiles@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
                 },
                 "sntp": {
                   "version": "0.2.4",
-                  "from": "sntp@>=0.2.0 <0.3.0"
+                  "from": "sntp@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
                 }
               }
             },
@@ -1004,9 +1037,9 @@
           }
         },
         "amqplib": {
-          "version": "0.3.2",
-          "from": "amqplib@>=0.3.1 <0.4.0",
-          "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.3.2.tgz",
+          "version": "0.4.0",
+          "from": "amqplib@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.4.0.tgz",
           "dependencies": {
             "bitsyntax": {
               "version": "0.0.4",
@@ -1040,7 +1073,8 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0"
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -1090,797 +1124,66 @@
             }
           }
         },
-        "sockjs-client-node": {
-          "version": "0.2.1",
-          "from": "sockjs-client-node@>=0.2.1 <0.3.0",
-          "resolved": "https://registry.npmjs.org/sockjs-client-node/-/sockjs-client-node-0.2.1.tgz",
+        "sockjs-client": {
+          "version": "1.0.3",
+          "from": "sockjs-client@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.0.3.tgz",
           "dependencies": {
-            "jsdom": {
-              "version": "3.1.2",
-              "from": "jsdom@>=3.1.0 <3.2.0",
-              "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-3.1.2.tgz",
+            "eventsource": {
+              "version": "0.1.6",
+              "from": "eventsource@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
               "dependencies": {
-                "browser-request": {
-                  "version": "0.3.3",
-                  "from": "browser-request@>=0.3.1 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz"
-                },
-                "contextify": {
-                  "version": "0.1.15",
-                  "from": "contextify@>=0.1.9 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/contextify/-/contextify-0.1.15.tgz",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1",
-                      "from": "bindings@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                    },
-                    "nan": {
-                      "version": "2.1.0",
-                      "from": "nan@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
-                    }
-                  }
-                },
-                "cssom": {
-                  "version": "0.3.0",
-                  "from": "cssom@>=0.3.0 <0.4.0",
-                  "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
-                },
-                "cssstyle": {
-                  "version": "0.2.30",
-                  "from": "cssstyle@>=0.2.21 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz"
-                },
-                "htmlparser2": {
-                  "version": "3.9.0",
-                  "from": "htmlparser2@>=3.7.3 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.0.tgz",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.3.0",
-                      "from": "domelementtype@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                    },
-                    "domhandler": {
-                      "version": "2.3.0",
-                      "from": "domhandler@>=2.3.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
-                    },
-                    "domutils": {
-                      "version": "1.5.1",
-                      "from": "domutils@>=1.5.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                      "dependencies": {
-                        "dom-serializer": {
-                          "version": "0.1.0",
-                          "from": "dom-serializer@>=0.0.0 <1.0.0",
-                          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-                          "dependencies": {
-                            "domelementtype": {
-                              "version": "1.1.3",
-                              "from": "domelementtype@>=1.1.1 <1.2.0",
-                              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "entities": {
-                      "version": "1.1.1",
-                      "from": "entities@>=1.1.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "2.0.4",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.6",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "nwmatcher": {
-                  "version": "1.3.7",
-                  "from": "nwmatcher@>=1.3.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz"
-                },
-                "parse5": {
-                  "version": "1.5.1",
-                  "from": "parse5@>=1.3.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
-                },
-                "request": {
-                  "version": "2.67.0",
-                  "from": "request@>=2.44.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
-                  "dependencies": {
-                    "bl": {
-                      "version": "1.0.0",
-                      "from": "bl@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
-                      "dependencies": {
-                        "readable-stream": {
-                          "version": "2.0.4",
-                          "from": "readable-stream@>=2.0.0 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.6",
-                              "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2",
-                              "from": "util-deprecate@>=1.0.1 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "caseless": {
-                      "version": "0.11.0",
-                      "from": "caseless@>=0.11.0 <0.12.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-                    },
-                    "extend": {
-                      "version": "3.0.0",
-                      "from": "extend@>=3.0.0 <3.1.0",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@>=0.6.1 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                    },
-                    "form-data": {
-                      "version": "1.0.0-rc3",
-                      "from": "form-data@>=1.0.0-rc3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-                      "dependencies": {
-                        "async": {
-                          "version": "1.5.0",
-                          "from": "async@>=1.4.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
-                        }
-                      }
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.8",
-                      "from": "mime-types@>=2.1.7 <2.2.0",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.20.0",
-                          "from": "mime-db@>=1.20.0 <1.21.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
-                        }
-                      }
-                    },
-                    "node-uuid": {
-                      "version": "1.4.7",
-                      "from": "node-uuid@>=1.4.7 <1.5.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-                    },
-                    "qs": {
-                      "version": "5.2.0",
-                      "from": "qs@>=5.2.0 <5.3.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.1",
-                      "from": "tunnel-agent@>=0.4.1 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.1",
-                      "from": "tough-cookie@>=2.2.0 <2.3.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-                    },
-                    "http-signature": {
-                      "version": "1.1.0",
-                      "from": "http-signature@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.5 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                        },
-                        "jsprim": {
-                          "version": "1.2.2",
-                          "from": "jsprim@>=1.2.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
-                          "dependencies": {
-                            "extsprintf": {
-                              "version": "1.0.2",
-                              "from": "extsprintf@1.0.2",
-                              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                            },
-                            "json-schema": {
-                              "version": "0.2.2",
-                              "from": "json-schema@0.2.2",
-                              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
-                            },
-                            "verror": {
-                              "version": "1.3.6",
-                              "from": "verror@1.3.6",
-                              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                            }
-                          }
-                        },
-                        "sshpk": {
-                          "version": "1.7.1",
-                          "from": "sshpk@>=1.7.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
-                          "dependencies": {
-                            "asn1": {
-                              "version": "0.2.3",
-                              "from": "asn1@>=0.2.3 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                            },
-                            "assert-plus": {
-                              "version": "0.2.0",
-                              "from": "assert-plus@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                            },
-                            "dashdash": {
-                              "version": "1.10.1",
-                              "from": "dashdash@>=1.10.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
-                              "dependencies": {
-                                "assert-plus": {
-                                  "version": "0.1.5",
-                                  "from": "assert-plus@>=0.1.0 <0.2.0",
-                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                                }
-                              }
-                            },
-                            "jsbn": {
-                              "version": "0.1.0",
-                              "from": "jsbn@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                            },
-                            "tweetnacl": {
-                              "version": "0.13.2",
-                              "from": "tweetnacl@>=0.13.0 <1.0.0",
-                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
-                            },
-                            "jodid25519": {
-                              "version": "1.0.2",
-                              "from": "jodid25519@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                            },
-                            "ecc-jsbn": {
-                              "version": "0.1.1",
-                              "from": "ecc-jsbn@>=0.0.1 <1.0.0",
-                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.0",
-                      "from": "oauth-sign@>=0.8.0 <0.9.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
-                    },
-                    "hawk": {
-                      "version": "3.1.2",
-                      "from": "hawk@>=3.1.0 <3.2.0",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "2.16.3",
-                          "from": "hoek@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                        },
-                        "boom": {
-                          "version": "2.10.1",
-                          "from": "boom@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                        },
-                        "cryptiles": {
-                          "version": "2.0.5",
-                          "from": "cryptiles@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                        },
-                        "sntp": {
-                          "version": "1.0.9",
-                          "from": "sntp@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                        }
-                      }
-                    },
-                    "aws-sign2": {
-                      "version": "0.6.0",
-                      "from": "aws-sign2@>=0.6.0 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5",
-                      "from": "stringstream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "from": "combined-stream@>=1.0.5 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                      "dependencies": {
-                        "delayed-stream": {
-                          "version": "1.0.0",
-                          "from": "delayed-stream@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@>=0.1.2 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0",
-                      "from": "is-typedarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-                    },
-                    "har-validator": {
-                      "version": "2.0.3",
-                      "from": "har-validator@>=2.0.2 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "from": "chalk@>=1.1.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.3",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "commander": {
-                          "version": "2.9.0",
-                          "from": "commander@>=2.9.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                          "dependencies": {
-                            "graceful-readlink": {
-                              "version": "1.0.1",
-                              "from": "graceful-readlink@>=1.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "is-my-json-valid": {
-                          "version": "2.12.3",
-                          "from": "is-my-json-valid@>=2.12.3 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
-                          "dependencies": {
-                            "generate-function": {
-                              "version": "2.0.0",
-                              "from": "generate-function@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                            },
-                            "generate-object-property": {
-                              "version": "1.2.0",
-                              "from": "generate-object-property@>=1.1.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                              "dependencies": {
-                                "is-property": {
-                                  "version": "1.0.2",
-                                  "from": "is-property@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                                }
-                              }
-                            },
-                            "jsonpointer": {
-                              "version": "2.0.0",
-                              "from": "jsonpointer@2.0.0",
-                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
-                            },
-                            "xtend": {
-                              "version": "4.0.1",
-                              "from": "xtend@>=4.0.0 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                            }
-                          }
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.1",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "xml-name-validator": {
+                "original": {
                   "version": "1.0.0",
-                  "from": "xml-name-validator@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-1.0.0.tgz"
-                },
-                "xmlhttprequest": {
-                  "version": "1.8.0",
-                  "from": "xmlhttprequest@>=1.6.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
-                },
-                "acorn-globals": {
-                  "version": "1.0.9",
-                  "from": "acorn-globals@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+                  "from": "original@>=0.0.5",
+                  "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz"
+                }
+              }
+            },
+            "faye-websocket": {
+              "version": "0.7.3",
+              "from": "faye-websocket@>=0.7.3 <0.8.0",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.6.4",
+                  "from": "websocket-driver@>=0.3.6",
+                  "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.4.tgz",
                   "dependencies": {
-                    "acorn": {
-                      "version": "2.6.4",
-                      "from": "acorn@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz"
-                    }
-                  }
-                },
-                "acorn": {
-                  "version": "0.11.0",
-                  "from": "acorn@0.11.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
-                },
-                "escodegen": {
-                  "version": "1.7.1",
-                  "from": "escodegen@>=1.6.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "1.9.3",
-                      "from": "estraverse@>=1.9.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "esprima": {
-                      "version": "1.2.5",
-                      "from": "esprima@>=1.2.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
-                    },
-                    "optionator": {
-                      "version": "0.5.0",
-                      "from": "optionator@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
-                      "dependencies": {
-                        "prelude-ls": {
-                          "version": "1.1.2",
-                          "from": "prelude-ls@>=1.1.1 <1.2.0",
-                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                        },
-                        "deep-is": {
-                          "version": "0.1.3",
-                          "from": "deep-is@>=0.1.2 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                        },
-                        "wordwrap": {
-                          "version": "0.0.3",
-                          "from": "wordwrap@>=0.0.2 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-                        },
-                        "type-check": {
-                          "version": "0.3.1",
-                          "from": "type-check@>=0.3.1 <0.4.0",
-                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
-                        },
-                        "levn": {
-                          "version": "0.2.5",
-                          "from": "levn@>=0.2.5 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
-                        },
-                        "fast-levenshtein": {
-                          "version": "1.0.7",
-                          "from": "fast-levenshtein@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
-                        }
-                      }
-                    },
-                    "source-map": {
-                      "version": "0.2.0",
-                      "from": "source-map@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-                      "dependencies": {
-                        "amdefine": {
-                          "version": "1.0.0",
-                          "from": "amdefine@>=0.0.4",
-                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                        }
-                      }
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "from": "websocket-extensions@>=0.1.1",
+                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
                     }
                   }
                 }
               }
             },
-            "primus": {
-              "version": "2.4.12",
-              "from": "primus@>=2.4.0 <2.5.0",
-              "resolved": "https://registry.npmjs.org/primus/-/primus-2.4.12.tgz",
-              "dependencies": {
-                "access-control": {
-                  "version": "0.0.8",
-                  "from": "access-control@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/access-control/-/access-control-0.0.8.tgz",
-                  "dependencies": {
-                    "millisecond": {
-                      "version": "0.1.2",
-                      "from": "millisecond@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz"
-                    },
-                    "vary": {
-                      "version": "1.0.1",
-                      "from": "vary@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
-                    }
-                  }
-                },
-                "create-server": {
-                  "version": "0.0.7",
-                  "from": "create-server@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/create-server/-/create-server-0.0.7.tgz",
-                  "dependencies": {
-                    "connected": {
-                      "version": "0.0.2",
-                      "from": "connected@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/connected/-/connected-0.0.2.tgz"
-                    }
-                  }
-                },
-                "diagnostics": {
-                  "version": "0.0.4",
-                  "from": "diagnostics@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-0.0.4.tgz",
-                  "dependencies": {
-                    "color": {
-                      "version": "0.7.3",
-                      "from": "color@>=0.7.0 <0.8.0",
-                      "resolved": "https://registry.npmjs.org/color/-/color-0.7.3.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "0.5.3",
-                          "from": "color-convert@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
-                        },
-                        "color-string": {
-                          "version": "0.2.4",
-                          "from": "color-string@>=0.2.0 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.0.1",
-                              "from": "color-name@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "colornames": {
-                      "version": "0.0.2",
-                      "from": "colornames@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz"
-                    },
-                    "env-variable": {
-                      "version": "0.0.3",
-                      "from": "env-variable@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz"
-                    },
-                    "kuler": {
-                      "version": "0.0.0",
-                      "from": "kuler@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz"
-                    },
-                    "text-hex": {
-                      "version": "0.0.0",
-                      "from": "text-hex@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz"
-                    }
-                  }
-                },
-                "eventemitter3": {
-                  "version": "0.1.6",
-                  "from": "eventemitter3@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
-                },
-                "forwarded-for": {
-                  "version": "0.1.1",
-                  "from": "forwarded-for@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-0.1.1.tgz"
-                },
-                "fusing": {
-                  "version": "0.4.0",
-                  "from": "fusing@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz",
-                  "dependencies": {
-                    "emits": {
-                      "version": "1.0.2",
-                      "from": "emits@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz"
-                    },
-                    "predefine": {
-                      "version": "0.1.2",
-                      "from": "predefine@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
-                      "dependencies": {
-                        "extendible": {
-                          "version": "0.1.1",
-                          "from": "extendible@>=0.1.0 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "load": {
-                  "version": "1.0.1",
-                  "from": "load@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/load/-/load-1.0.1.tgz"
-                },
-                "setheader": {
-                  "version": "0.0.4",
-                  "from": "setheader@>=0.0.0 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/setheader/-/setheader-0.0.4.tgz",
-                  "dependencies": {
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@>=0.7.0 <0.8.0"
-                    }
-                  }
-                },
-                "ultron": {
-                  "version": "1.0.2",
-                  "from": "ultron@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
-                }
-              }
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
-            "ws": {
-              "version": "0.7.2",
-              "from": "ws@>=0.7.0 <0.8.0",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-0.7.2.tgz",
+            "json3": {
+              "version": "3.3.2",
+              "from": "json3@>=3.3.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+            },
+            "url-parse": {
+              "version": "1.0.5",
+              "from": "url-parse@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
               "dependencies": {
-                "options": {
-                  "version": "0.0.6",
-                  "from": "options@>=0.0.5",
-                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                "querystringify": {
+                  "version": "0.0.3",
+                  "from": "querystringify@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.3.tgz"
                 },
-                "ultron": {
-                  "version": "1.0.2",
-                  "from": "ultron@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
-                },
-                "bufferutil": {
-                  "version": "1.1.0",
-                  "from": "bufferutil@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-1.1.0.tgz",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1",
-                      "from": "bindings@>=1.2.0 <1.3.0",
-                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                    },
-                    "nan": {
-                      "version": "1.8.4",
-                      "from": "nan@>=1.8.0 <1.9.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-                    }
-                  }
-                },
-                "utf-8-validate": {
-                  "version": "1.1.0",
-                  "from": "utf-8-validate@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-1.1.0.tgz",
-                  "dependencies": {
-                    "bindings": {
-                      "version": "1.2.1",
-                      "from": "bindings@>=1.2.0 <1.3.0",
-                      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz"
-                    },
-                    "nan": {
-                      "version": "1.8.4",
-                      "from": "nan@>=1.8.0 <1.9.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
-                    }
-                  }
+                "requires-port": {
+                  "version": "1.0.0",
+                  "from": "requires-port@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
                 }
               }
             }
@@ -1904,13 +1207,13 @@
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
         },
         "xmlbuilder": {
-          "version": "4.1.0",
+          "version": "4.2.0",
           "from": "xmlbuilder@>=2.4.6",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.5.0 <4.0.0",
+              "from": "lodash@>=3.6.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
             }
           }

--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -52,6 +52,11 @@ export default class Artifacts {
     let task;
     try {
       task = await this.index.findTask(namespace);
+      if (task.message && task.message === 'Indexed task not found') {
+        let error = new Error(task.message)
+        error.code = 404;
+        throw error;
+      }
     } catch (e) {
       // 404 will throw so validate before returning null...
       if (e.code && e.code != 404){


### PR DESCRIPTION
So it looks like regenerating the shrinkwrap was the solution to the tests even on master failing.  Since the dependency changed for slugid, it wasn't picked up in the shrinkwrap file which is what gets installed (results in slugid not installed).

After running the tests there was a test that needed to be updated.