### PR TITLE
Bug 1240018 - Remove repos that cannot be cached

### DIFF
--- a/src/cli/moz-cache.js
+++ b/src/cli/moz-cache.js
@@ -65,12 +65,7 @@ export default async function main(config, argv) {
         ['emulator_url', 'flame-kk'],
         ['emulator_url', 'nexus-4'],
         ['emulator_url', 'emulator-l'],
-        ['emulator_url', 'dolphin'],
-        ['emulator_url', 'dolphin-512'],
-        ['g_emulator_url', 'emulator.xml'],
-        ['g_emulator_url', 'emulator-jb.xml'],
-        ['g_emulator_url', 'emulator-kk.xml'],
-        ['g_emulator_url', 'emulator-l.xml']
+        ['emulator_url', 'dolphin']
     ];
 
     var scheduler = new Scheduler({


### PR DESCRIPTION
These repos have issues with being cached so they should be removed from the list of cached repos that are submitted periodically.