### PR TITLE
Use 2.3.24 for cloning b2g emulator/device repos

### DIFF
--- a/src/cli/moz-cache.js
+++ b/src/cli/moz-cache.js
@@ -203,7 +203,10 @@ function generateRepoCacheTaskDefinition(emulator, type) {
       scopes: ['queue:create-artifact:*', 'index:insert-task:tc-vcs.v1.repo-project.*'],
       routes: [`index.tc-vcs.v1.repo-project.${indexHash}`],
       payload: {
-        image: 'taskcluster/taskcluster-vcs:2.3.28',
+        // TODO (garndt): Bug here with cloning android repos that happened sometime 
+        // between 2.3.24 and 2.3.29.  Since we are in the process of disabling these
+        // jobs, putting this on a known good version for the time being should be sufficient.
+        image: 'taskcluster/taskcluster-vcs:2.3.24',
         command: params,
         maxRunTime: 3600,
         features: {


### PR DESCRIPTION
Sometime between 2.3.24 and 2.3.29 something was introduced that started causing these to fail with new things added to the repos.  Possibly large files, number of files, or something else.  Since we are are in the process of removing these from being cached as jobs requiring them decrease, for now this should be a good temporary work around to get the repos cached again.