### PR TITLE
Update worker type to use tc-vcs specific worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ RUN git config --global user.email "taskcluster-vcs@example.nomail" && \
     git config --global user.name "Taskcluster VCS" && \
     git config --global gc.auto 0
 
-RUN npm install -g taskcluster-vcs@2.3.32 --no-optional
+RUN npm install -g taskcluster-vcs@2.3.33 --no-optional
 ENTRYPOINT ["tc-vcs"]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-vcs",
-  "version": "2.3.32",
+  "version": "2.3.33",
   "description": "Version control tools for taskcluster images",
   "main": "./build/bin/tc-vcs",
   "preferGlobal": true,

--- a/src/cli/moz-cache.js
+++ b/src/cli/moz-cache.js
@@ -153,7 +153,7 @@ function generateCloneTaskDefinition(repo) {
 
     var task = {
       provisionerId: 'aws-provisioner-v1',
-      workerType: 'gaia',
+      workerType: 'tcvcs-cache',
       created: date,
       deadline: deadline,
       scopes: ['queue:create-artifact:*', 'index:insert-task:tc-vcs.v1.clones.*'],

--- a/src/cli/moz-cache.js
+++ b/src/cli/moz-cache.js
@@ -158,7 +158,7 @@ function generateCloneTaskDefinition(repo) {
       deadline: deadline,
       scopes: ['queue:create-artifact:*', 'index:insert-task:tc-vcs.v1.clones.*'],
       payload: {
-        image: 'taskcluster/taskcluster-vcs:2.3.32',
+        image: 'taskcluster/taskcluster-vcs:2.3.33',
         command: params,
         maxRunTime: 3600,
         features: {


### PR DESCRIPTION
This allows us to isolate failures to tasks only running for tc-vcs and have alerting/graphing around that.

Here is a task using this new worker type: https://tools.taskcluster.net/task-inspector/#cq-d9rREROq8CbwIbEU4qQ/0