### PR TITLE
Increase max run time of emulator/device caching

### DIFF
--- a/src/cli/moz-cache.js
+++ b/src/cli/moz-cache.js
@@ -212,7 +212,7 @@ function generateRepoCacheTaskDefinition(emulator, type) {
         // jobs, putting this on a known good version for the time being should be sufficient.
         image: 'taskcluster/taskcluster-vcs:2.3.24',
         command: params,
-        maxRunTime: 3600,
+        maxRunTime: 7200,
         features: {
           taskclusterProxy: true
         },


### PR DESCRIPTION
There are times where previous caching jobs left the caches in an inconsistent state causing new jobs to do full clones.  Doing full clones on some of the emulator repos takes longer than 1 hour.