### PR TITLE
Increase the expiration of tasks and artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,5 @@ RUN git config --global user.email "taskcluster-vcs@example.nomail" && \
 # Install node
 RUN cd /usr/local/ && curl https://nodejs.org/dist/v0.12.4/node-v0.12.4-linux-x64.tar.gz | tar -xz --strip-components 1
 
-RUN npm install -g taskcluster-vcs@2.3.40 --no-optional
+RUN npm install -g taskcluster-vcs@2.3.41 --no-optional
 ENTRYPOINT ["tc-vcs"]
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-vcs",
-  "version": "2.3.40",
+  "version": "2.3.41",
   "description": "Version control tools for taskcluster images",
   "main": "./build/bin/tc-vcs",
   "preferGlobal": true,

--- a/src/artifacts.js
+++ b/src/artifacts.js
@@ -180,7 +180,7 @@ export default class Artifacts {
     options = Object.assign({
       taskId: process.env.TASK_ID,
       runId: process.env.RUN_ID,
-      expires: new Date(Date.now() + ms('30 days')),
+      expires: new Date(Date.now() + ms('1 year')),
       rank: Date.now()
     }, options);
 

--- a/src/cli/moz-cache.js
+++ b/src/cli/moz-cache.js
@@ -181,7 +181,7 @@ function generateCloneTaskDefinition(repo) {
       deadline: deadline,
       scopes: ['queue:create-artifact:*', 'index:insert-task:tc-vcs.v1.clones.*'],
       payload: {
-        image: 'taskcluster/taskcluster-vcs:2.3.40',
+        image: 'taskcluster/taskcluster-vcs:2.3.41',
         command: params,
         maxRunTime: 3600,
         features: {
@@ -230,10 +230,7 @@ function generateRepoCacheTaskDefinition(emulator, type) {
       scopes: ['queue:create-artifact:*', 'index:insert-task:tc-vcs.v1.repo-project.*'],
       routes: [`index.tc-vcs.v1.repo-project.${indexHash}`],
       payload: {
-        // TODO (garndt): Bug here with cloning android repos that happened sometime
-        // between 2.3.24 and 2.3.29.  Since we are in the process of disabling these
-        // jobs, putting this on a known good version for the time being should be sufficient.
-        image: 'taskcluster/taskcluster-vcs:2.3.40',
+        image: 'taskcluster/taskcluster-vcs:2.3.41',
         command: params,
         maxRunTime: 7200,
         features: {

--- a/src/clitools.js
+++ b/src/clitools.js
@@ -76,7 +76,7 @@ export let arg = {
 
   expires(parser) {
     parser.addArgument(['--expires'], {
-      defaultValue: '30 days',
+      defaultValue: '1 year',
       type: (v) => {
         return new Date(Date.now() + ms(v));
       },


### PR DESCRIPTION
tc-vcs is being deprecreated.  Release a new version that will cache
artifacts for 1 year to allow scheduling of tc-vcs caching to be
disabled.